### PR TITLE
update watch file to new upstream location

### DIFF
--- a/debian/watch
+++ b/debian/watch
@@ -1,2 +1,2 @@
 version=3
-https://github.com/rthomsen/kcmsystemd//releases .*/(?:kcmsystemd-)?(\d\S+)\.tar\.(?:bz2|gz|xz)
+http://download.kde.org/stable/systemd-kcm/ systemd-kcm-?(\d\S+)\.tar\.(?:bz2|gz|xz)


### PR DESCRIPTION
@shsorbom 

Hi,

I guess you're waiting on KDE 5 to package a new version in Debian.

Anyway, here's an updated watch file.
```
uscan --report
Processing watchfile line for package kde-config-systemd...
Newest version on remote site is 1.2.0, local version is 0.7.0
kde-config-systemd: Newer version (1.2.0) available on remote site:
  http://download.kde.org/stable/systemd-kcm/systemd-kcm-1.2.0.tar.xz
```

Nice recap:
https://rthomsen6.wordpress.com/2015/07/06/systemd-kcm-1-2-0-released/

@rthomsen 